### PR TITLE
ensure close is invoked even in case of error

### DIFF
--- a/tpp.rb
+++ b/tpp.rb
@@ -1778,5 +1778,8 @@ else
   usage
 end # case
 
-ctrl.run
-ctrl.close
+begin
+  ctrl.run
+ensure
+  ctrl.close
+end


### PR DESCRIPTION
error may happen when trying to open non utf8 file in a utf8 os