### PR TITLE
updated: Makefile and README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 # Latest Change: Sam Jul 31 00:58:01 CEST 2004 
 #################################################
 
+AUTOMAKE_OPTIONS = foreign
 BIN = tpp  
 prefix=/usr/local
 INSPATH= $(prefix)/bin/
@@ -13,7 +14,7 @@ all:
 
 install :
 	mkdir -p $(DOCPATH)	
-	install -m644 DESIGN CHANGES COPYING README THANKS $(DOCPATH)	
+	install -m644 DESIGN CHANGES COPYING THANKS $(DOCPATH)	
 	install -m644 doc/tpp.1 $(MANPATH)
 	install tpp.rb $(INSPATH)$(BIN)		
 	mkdir -p $(DOCPATH)/contrib

--- a/README.org
+++ b/README.org
@@ -13,7 +13,7 @@ the Linux framebuffer to an xterm.
    Prerequisites: 
    * Ruby 1.8 <http://www.ruby-lang.org/>
    * a recent version of ncurses
-   * ncurses-ruby <http://ncurses-ruby.berlios.de/>
+   * ncurses-ruby <https://github.com/eclubb/ncurses-ruby>
 
    Optionally:
    * FIGlet (if you want to have huge text printed)
@@ -26,7 +26,9 @@ the Linux framebuffer to an xterm.
 
 Start tpp with the presentation file you would like to display:
 
+#+BEGIN_EXAMPLE
 $ tpp presentation.tpp
+#+END_EXAMPLE
 
 To control tpp, the following keys are available:
 #+BEGIN_EXAMPLE
@@ -51,6 +53,8 @@ this point.
 When you press 'l' (lower-case L) or 'L', the file you have currently loaded
 into tpp will be reloaded from disk. This is very useful when you write
 presentations with tpp, and constantly need a preview.
+
+[[https://i.imgur.com/dJBxz0x.gif]]
 
 ** Writing tpp presentations
 


### PR DESCRIPTION
- Makefile have been updated to accommodate changes README file name, causing an error during make.
- demo presentation have been added to README.
- link to ncurses-ruby was dead, added a new link